### PR TITLE
Add options parameter and implement ignoreNumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Using npm:
 $ npm i snakify
 ```
 
+## Usage
+
 In Node.js:
 
 ```js
@@ -18,5 +20,19 @@ import snakify from 'snakify' // const snakify = require('snakify');
 snakify({ numVal: 1, strVal: 'camelCase', boolVal: true })
 // { num_val: 1, str_val: 'camelCase', bool_val: true }
 ```
+
+### Supoorted Options
+
+```js
+const options = {
+  // Look at the options below
+  ignoreNumber: true
+}
+
+snakify({ txL7Size: 1, rxSizeL7: true }, options);
+// { tx_l7_size: 1, rx_size_l7: true }
+```
+
+- With `ignoreNumber`, doesn't do snake case conversion that describes numbers.
 
 See the [test-case](./snakify.test.js) for other usage.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,7 @@
-export default function snakify<T>(obj: T): T
+export interface SnakifyOptions {
+  ignoreNumber: boolean;
+}
+
+export default function snakify<T>(obj: T, options?: SnakifyOptions): T
 
 export as namespace snakify

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const isBoolean = value => typeof value === 'boolean'
 
 const anyPass = (value, ...predictors) => predictors.some(predictor => predictor(value))
 
-const snakify = obj => {
+const snakify = (obj, options) => {
   if (isArray(obj)) {
     return obj.map(item => snakify(item))
   }
@@ -20,9 +20,35 @@ const snakify = obj => {
   return Object
     .entries(obj)
     .reduceRight(
-      (acc, [ key, value ]) => Object.assign({ [ snakeCase(key) ]: snakify(value) }, acc),
+      (acc, [ key, value ]) => 
+        Object.assign(
+          { [ processOptions(snakeCase(key), options) ]: snakify(value) }, 
+          acc,
+        ),
       {},
     )
+}
+
+const optionProcessor = {
+  ignoreNumber,
+}
+
+function processOptions(key, options) {
+  if (!options) {
+    return key
+  }
+
+  let result = key
+
+  Object.keys(options).forEach(name => {
+    result = optionProcessor[name](key)
+  })
+
+  return result
+}
+
+function ignoreNumber(key) {
+  return key.replace(/(_)([0-9])+/g, `$2`)
 }
 
 module.exports = snakify

--- a/snakify.test.js
+++ b/snakify.test.js
@@ -39,3 +39,22 @@ test('array case', () => {
 
   expect(snakify(given)).toEqual(expected)
 })
+
+test('ignoreNumber option case', () => {
+  const given = {
+    txL7Size: [ 1, 'camelCaseArrVal', true ],
+    txL4Size: [
+      { numVal: 1, strVal: 'camelCase', boolVal: true },
+      { numVal: 1, strVal: 'camelCase', boolVal: true },
+    ],
+  }
+  const expected = {
+    tx_l7_size: [ 1, 'camelCaseArrVal', true ],
+    tx_l4_size: [
+      { num_val: 1, str_val: 'camelCase', bool_val: true },
+      { num_val: 1, str_val: 'camelCase', bool_val: true },
+    ],
+  }
+
+  expect(snakify(given, { ignoreNumber: true })).toEqual(expected)
+})

--- a/snakify.test.js
+++ b/snakify.test.js
@@ -42,18 +42,22 @@ test('array case', () => {
 
 test('ignoreNumber option case', () => {
   const given = {
-    txL7Size: [ 1, 'camelCaseArrVal', true ],
-    txL4Size: [
+    arrV1Val: [ 1, 'camelCaseArrVal', true ],
+    arrV1Obj: [
       { numVal: 1, strVal: 'camelCase', boolVal: true },
       { numVal: 1, strVal: 'camelCase', boolVal: true },
     ],
+    hello1World: 'hello1World',
+    helloW1Orld: 'helloW1Orld',
   }
   const expected = {
-    tx_l7_size: [ 1, 'camelCaseArrVal', true ],
-    tx_l4_size: [
+    arr_v1_val: [ 1, 'camelCaseArrVal', true ],
+    arr_v1_obj: [
       { num_val: 1, str_val: 'camelCase', bool_val: true },
       { num_val: 1, str_val: 'camelCase', bool_val: true },
     ],
+    hello1_world: 'hello1World',
+    hello_w1_orld: 'helloW1Orld',
   }
 
   expect(snakify(given, { ignoreNumber: true })).toEqual(expected)


### PR DESCRIPTION
숫자에 대해선 snake로 나누지 않는 옵션을 추가합니다.

```typescript
  const given = {
    txL7Size: [ 1, 'camelCaseArrVal', true ],
    txL4Size: [
      { numVal: 1, strVal: 'camelCase', boolVal: true },
      { numVal: 1, strVal: 'camelCase', boolVal: true },
    ],
  }
  const expected = {
    tx_l7_size: [ 1, 'camelCaseArrVal', true ],
    tx_l4_size: [
      { num_val: 1, str_val: 'camelCase', bool_val: true },
      { num_val: 1, str_val: 'camelCase', bool_val: true },
    ],
  }

  expect(snakify(given, { ignoreNumber: true })).toEqual(expected)
```

