### PR TITLE
Remove snakify call on the Object value

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const snakify = obj => {
   return Object
     .entries(obj)
     .reduceRight(
-      (acc, [ key, value ]) => Object.assign({ [ snakeCase(key) ]: snakify(value) }, acc),
+      (acc, [ key, value ]) => Object.assign({ [ snakeCase(key) ]: value }, acc),
       {},
     )
 }


### PR DESCRIPTION
# Overview

This prevents data from being mutated. The readme file states that this package `Convert keys to snake case`, however prior to this change it was also converting values. For Date objects the returned result was an empty object.